### PR TITLE
 Avoid create XMLs for blocks of text chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Usage:
 
 Options:
   <resource-file>       The resource file to work on.
-  <chunk-id>            The chunk identifier. Defaults to decimal, use "0x" as prefix for hexadecimal.
-  --block=<block-id>    The block identifier. Defaults to decimal, use "0x" as prefix for hexadecimal. [default: 0]
+  <chunk-id>            The chunk identifier. Defaults to decimal, use "0x" as prefix for hexadecimal. "all" for all.
+  --block=<block-id>    The block identifier. Defaults to decimal, use "0x" as prefix for hexadecimal. "all" for all. [default: 0]
   --raw                 With this flag, the chunk will be exported without conversion to a common file format.
   --pal=<palette-file>  For handling bitmaps & models, use this palette file to write color information
   --fps=<framerate>     The frames per second to emulate when exporting movies. 0 names files after timestamp. [default: 0]
@@ -33,7 +33,7 @@ For exporting, basic formats will be exported as known file types. Specifying --
 Files are imported raw as well, unless a conversion is known.
 
 The following formats are supported for import and export: .wav for audio, .png for images
-The following format is supported for export only: .obj (Wavefront) for geometry, .wav/.png/.srt for movies.
+The following format is supported for export only: .xml for text strings, .obj (Wavefront) for geometry, .wav/.png/.srt for movies.
 
 ### Movie handling
 When movies are exported, the optional ```fps``` parameter specifies which framerate to emulate. Videos in the resource files don't follow a strict framerate and frames can't be directly used as stills. If the parameter is 0, the filename will contain the offset in ```sss.fff``` format for seconds and fractions (milliseconds). Any other value will have the export code to duplicate frames to reach the requested framerate. In this case, the filename will contain a 4-digit framenumber.

--- a/main.go
+++ b/main.go
@@ -164,7 +164,10 @@ func exportFile(provider chunk.Provider, holder chunk.BlockHolder, blockID uint1
 			} else if contentType == res.VideoClip {
 				exportRaw = exportVideoClip(provider, blockData, outFileName, framesPerSecond, palette)
 			} else if contentType == res.Text {
-				exportRaw = !convert.ToTxt(outFileName+".xml", holder)
+				// Don't recreate whole XML for each block since convert.ToTxt merge them into one file
+				if blockID == 0 {
+					exportRaw = !convert.ToTxt(outFileName+".xml", holder)
+				}
 			} else {
 				exportRaw = true
 			}


### PR DESCRIPTION
When supplied `export --block=all` option, chunkie creates multiple identical XMLs for each block of text chunk. This commit force to export only for first block and ignore others.